### PR TITLE
Use `expansion()` if ggplot2 version >= 3.2.1

### DIFF
--- a/R/bar_chart.R
+++ b/R/bar_chart.R
@@ -76,8 +76,7 @@ bar_chart <- function(data, x, y, facet = NULL, ..., bar_color = "#1F77B4",
 
   p <- ggplot(data, aes(!!x, !!y, ...)) +
     eval(.geom_col) +
-    theme_discrete_chart(horizontal) +
-    scale_y_continuous(expand = expand_scale(mult = c(0, 0.05)))
+    theme_discrete_chart(horizontal)
 
   post_process_plot(
     plot = p,

--- a/R/lollipop_chart.R
+++ b/R/lollipop_chart.R
@@ -94,8 +94,7 @@ lollipop_chart <- function(data, x, y, facet = NULL, ..., line_size = 0.75,
   p <- ggplot(data, aes(!!x, !!y, ...)) +
     eval(.geom_segment) +
     eval(.geom_point) +
-    theme_discrete_chart(horizontal) +
-    scale_y_continuous(expand = expand_scale(mult = c(0, 0.05)))
+    theme_discrete_chart(horizontal)
 
   post_process_plot(
     plot = p,

--- a/R/post_process_plot.R
+++ b/R/post_process_plot.R
@@ -26,7 +26,11 @@ post_process_plot <- function(plot, horizontal = TRUE, facet = NULL,
       scale_x_reordered()
   }
 
-  plot
+  if (utils::packageVersion("ggplot2") >= "3.2.1") {
+    expand_scale <- expansion
+  }
+
+  plot + scale_y_continuous(expand = expand_scale(mult = c(0, 0.05)))
 }
 
 create_highlight_colors <- function(highlight, color) {


### PR DESCRIPTION
This avoids a warning saying that `expand_scale()` is deprecated.