### PR TITLE
avoid matrices in filter()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,6 @@ URL: https://thomas-neitmann.github.io/ggcharts/index.html, https://github.com/t
 BugReports: https://github.com/thomas-neitmann/ggcharts/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr
 Language: en-US

--- a/R/diverging_chart.R
+++ b/R/diverging_chart.R
@@ -37,7 +37,7 @@
 #' mtcars_z <- dplyr::transmute(
 #'   .data = mtcars,
 #'   model = row.names(mtcars),
-#'   hpz = scale(hp)
+#'   hpz = scale(hp)[, 1]
 #' )
 #'
 #' diverging_bar_chart(mtcars_z, model, hpz)
@@ -112,7 +112,7 @@ diverging_bar_chart <- function(data, x, y,
 #' mtcars_z <- dplyr::transmute(
 #'   .data = mtcars,
 #'   model = row.names(mtcars),
-#'   hpz = scale(hp)
+#'   hpz = scale(hp)[, 1]
 #' )
 #'
 #' diverging_lollipop_chart(mtcars_z, model, hpz)

--- a/man/diverging_bar_chart.Rd
+++ b/man/diverging_bar_chart.Rd
@@ -38,21 +38,21 @@ if (requireNamespace("tidyr")) {
   library(magrittr)
   data(biomedicalrevenue)
   biomedicalrevenue \%>\%
-  dplyr::filter(year > 2016) \%>\%
-  tidyr::pivot_wider(
-    values_from = revenue,
-    names_from = year,
-    names_prefix = "revenue_"
-  ) \%>\%
-  dplyr::mutate(diff = revenue_2018 - revenue_2017) \%>\%
-  diverging_bar_chart(company, diff)
+    dplyr::filter(year > 2016) \%>\%
+    tidyr::pivot_wider(
+      values_from = revenue,
+      names_from = year,
+      names_prefix = "revenue_"
+    ) \%>\%
+    dplyr::mutate(diff = revenue_2018 - revenue_2017) \%>\%
+    diverging_bar_chart(company, diff)
 }
 
 data(mtcars)
 mtcars_z <- dplyr::transmute(
   .data = mtcars,
   model = row.names(mtcars),
-  hpz = scale(hp)
+  hpz = scale(hp)[, 1]
 )
 
 diverging_bar_chart(mtcars_z, model, hpz)
@@ -65,7 +65,6 @@ diverging_bar_chart(mtcars_z, model, hpz, text_size = 8)
 
 ## Display the axis label text in the same color as the bars
 diverging_bar_chart(mtcars_z, model, hpz, text_color = c("#1F77B4", "#FF7F0E"))
-
 }
 \seealso{
 To learn how to further customize this plot have a look at the 'customize' vignette:

--- a/man/diverging_lollipop_chart.Rd
+++ b/man/diverging_lollipop_chart.Rd
@@ -44,21 +44,21 @@ if (requireNamespace("tidyr")) {
   library(magrittr)
   data(biomedicalrevenue)
   biomedicalrevenue \%>\%
-  dplyr::filter(year > 2016) \%>\%
-  tidyr::pivot_wider(
-    values_from = revenue,
-    names_from = year,
-    names_prefix = "revenue_"
-  ) \%>\%
-  dplyr::mutate(diff = revenue_2018 - revenue_2017) \%>\%
-  diverging_lollipop_chart(company, diff)
+    dplyr::filter(year > 2016) \%>\%
+    tidyr::pivot_wider(
+      values_from = revenue,
+      names_from = year,
+      names_prefix = "revenue_"
+    ) \%>\%
+    dplyr::mutate(diff = revenue_2018 - revenue_2017) \%>\%
+    diverging_lollipop_chart(company, diff)
 }
 
 data(mtcars)
 mtcars_z <- dplyr::transmute(
   .data = mtcars,
   model = row.names(mtcars),
-  hpz = scale(hp)
+  hpz = scale(hp)[, 1]
 )
 
 diverging_lollipop_chart(mtcars_z, model, hpz)
@@ -71,7 +71,6 @@ diverging_lollipop_chart(mtcars_z, model, hpz, text_size = 8)
 
 ## Display the axis label text in the same color as the bars
 diverging_lollipop_chart(mtcars_z, model, hpz, text_color = c("#1F77B4", "#FF7F0E"))
-
 }
 \seealso{
 To learn how to further customize this plot have a look at the 'customize' vignette:


### PR DESCRIPTION
We're about to release dplyr 1.0.8 and this package currently fail against it, because one example uses matrices in `filter()` and we are trying to be stricter about what is allowed. 

We currently see: 

````
── After ─────────────────────────────────────────────────────────────────────────────────────────────────────
> checking examples ... ERROR
  Running examples in ‘ggcharts-Ex.R’ failed
  The error most likely occurred in:
  
  > ### Name: diverging_bar_chart
  > ### Title: Diverging Bar Chart
  > ### Aliases: diverging_bar_chart
  > 
  > ### ** Examples
  > 
  > if (requireNamespace("tidyr")) {
  +   library(magrittr)
  +   data(biomedicalrevenue)
  +   biomedicalrevenue %>%
  +   dplyr::filter(year > 2016) %>%
  +   tidyr::pivot_wider(
  +     values_from = revenue,
  +     names_from = year,
  +     names_prefix = "revenue_"
  +   ) %>%
  +   dplyr::mutate(diff = revenue_2018 - revenue_2017) %>%
  +   diverging_bar_chart(company, diff)
  + }
  Loading required namespace: tidyr
  > 
  > data(mtcars)
  > mtcars_z <- dplyr::transmute(
  +   .data = mtcars,
  +   model = row.names(mtcars),
  +   hpz = scale(hp)
  + )
  > 
  > diverging_bar_chart(mtcars_z, model, hpz)
  Error: Problem while computing `..1 = hpz >= 0`.
  ✖ Input `..1` must be a logical vector, not a logical[,1].
  Backtrace:
       ▆
    1. ├─ggcharts::diverging_bar_chart(mtcars_z, model, hpz)
    2. │ └─ggcharts:::diverging_chart(...)
    3. │   ├─ggplot2::geom_text(...)
    4. │   │ └─ggplot2::layer(...)
    5. │   │   └─ggplot2::fortify(data)
    6. │   ├─dplyr::filter(data, !!y >= 0)
    7. │   └─dplyr:::filter.data.frame(data, !!y >= 0)
    8. │     └─dplyr:::filter_rows(.data, ..., caller_env = caller_env())
    9. │       └─dplyr:::filter_eval(dots, mask = mask, error_call = error_call)
   10. │         ├─base::withCallingHandlers(...)
   11. │         └─mask$eval_all_filter(dots, env_filter)
   12. ├─dplyr:::dplyr_internal_error(...)
   13. │ └─rlang::abort(class = c(class, "dplyr:::internal_error"), dplyr_error_data = data)
   14. │   └─rlang:::signal_abort(cnd, .file)
   15. │     └─base::signalCondition(cnd)
   16. └─dplyr `<fn>`(`<dpl:::__>`)
  Execution halted

1 error x | 0 warnings ✓ | 0 notes ✓
````

I have submitted a pull request to dplyr so that you'd get a warning for a matrix with 1 column, instead of an error: https://github.com/tidyverse/dplyr/pull/6083 but I still believe using matrices (even with just one columns) should be avoided altogether, which is what this pull request does. 
